### PR TITLE
Add current user name and color to game ID screen

### DIFF
--- a/client/src/main/kotlin/ticketToRide/App.kt
+++ b/client/src/main/kotlin/ticketToRide/App.kt
@@ -102,6 +102,8 @@ val App = FC<AppProps> { props ->
                             )
                         )
                     }
+                    playerName = it.me.name
+                    playerColor = it.me.color
                 }
 
             is Screen.GameInProgress ->

--- a/client/src/main/kotlin/ticketToRide/components/PlayersListComponent.kt
+++ b/client/src/main/kotlin/ticketToRide/components/PlayersListComponent.kt
@@ -44,7 +44,6 @@ private val playersListComponent = FC<PlayersListComponentProps> { props ->
                     }
                 }
 
-
                 div {
                     css {
                         width = 100.pct
@@ -56,17 +55,24 @@ private val playersListComponent = FC<PlayersListComponentProps> { props ->
                     }
                     div {
                         css {
-                            display = Display.inlineBlock
-                            width = 12.px
-                            height = 12.px
-                            backgroundColor = Color(player.color.rgb)
-                            borderRadius = 50.pct
-                            marginRight = 8.px
+                            display = Display.flex
+                            flexDirection = FlexDirection.row
+                            alignItems = AlignItems.center
                         }
-                    }
-                    Typography {
-                        variant = TypographyVariant.h6
-                        +player.name.value
+                        div {
+                            css {
+                                display = Display.inlineBlock
+                                width = 12.px
+                                height = 12.px
+                                backgroundColor = Color(player.color.rgb)
+                                borderRadius = 50.pct
+                                marginRight = 8.px
+                            }
+                        }
+                        Typography {
+                            variant = TypographyVariant.h6
+                            +player.name.value
+                        }
                     }
                     player.points?.let {
                         pointsLabel(it.toString(), NamedColor.lightyellow)

--- a/client/src/main/kotlin/ticketToRide/components/PlayersListComponent.kt
+++ b/client/src/main/kotlin/ticketToRide/components/PlayersListComponent.kt
@@ -54,6 +54,16 @@ private val playersListComponent = FC<PlayersListComponentProps> { props ->
                         alignItems = AlignItems.center
                         paddingRight = 16.px
                     }
+                    div {
+                        css {
+                            display = Display.inlineBlock
+                            width = 12.px
+                            height = 12.px
+                            backgroundColor = Color(player.color.rgb)
+                            borderRadius = 50.pct
+                            marginRight = 8.px
+                        }
+                    }
                     Typography {
                         variant = TypographyVariant.h6
                         +player.name.value

--- a/client/src/main/kotlin/ticketToRide/screens/ShowGameIdScreen.kt
+++ b/client/src/main/kotlin/ticketToRide/screens/ShowGameIdScreen.kt
@@ -2,6 +2,8 @@ package ticketToRide.screens
 
 import csstype.pct
 import csstype.px
+import csstype.Color
+import csstype.NamedColor
 import emotion.react.css
 import kotlinx.browser.window
 import mui.material.*
@@ -9,6 +11,7 @@ import mui.system.sx
 import react.*
 import react.dom.html.ReactHTML.a
 import react.dom.html.ReactHTML.p
+import react.dom.html.ReactHTML.span
 import ticketToRide.*
 import web.window.WindowTarget
 
@@ -56,10 +59,17 @@ val ShowGameIdScreen = FC<ShowGameIdScreenProps> { props ->
                 }
             }
             p {
+                span {
+                    css {
+                        display = csstype.Display.inlineBlock
+                        width = 12.px
+                        height = 12.px
+                        backgroundColor = Color(props.playerColor.rgb)
+                        borderRadius = 50.pct
+                        marginRight = 8.px
+                    }
+                }
                 +"Player Name: ${props.playerName.value}"
-            }
-            p {
-                +"Player Color: ${props.playerColor.name}"
             }
         }
         DialogActions {

--- a/client/src/main/kotlin/ticketToRide/screens/ShowGameIdScreen.kt
+++ b/client/src/main/kotlin/ticketToRide/screens/ShowGameIdScreen.kt
@@ -16,6 +16,8 @@ external interface ShowGameIdScreenProps : Props {
     var gameId: GameId
     var locale: Locale
     var onClosed: () -> Unit
+    var playerName: PlayerName
+    var playerColor: PlayerColor
 }
 
 @JsExport
@@ -52,6 +54,12 @@ val ShowGameIdScreen = FC<ShowGameIdScreenProps> { props ->
                     target = WindowTarget._blank
                     +gameUrl
                 }
+            }
+            p {
+                +"Player Name: ${props.playerName.value}"
+            }
+            p {
+                +"Player Color: ${props.playerColor.name}"
             }
         }
         DialogActions {


### PR DESCRIPTION
Add the current user's name and color to the screen displaying the game ID and link.

* Modify `ShowGameIdScreenProps` in `client/src/main/kotlin/ticketToRide/screens/ShowGameIdScreen.kt` to include `playerName` and `playerColor` props.
* Display the current user's name and color in the `DialogContent` section of `ShowGameIdScreen`.
* Update `App` component in `client/src/main/kotlin/ticketToRide/App.kt` to pass the current user's name and color to the `ShowGameIdScreen` component when the game starts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Kiryushin-Andrey/TicketToRide?shareId=7b508b83-b3b1-438d-a27e-64d321661c8a).